### PR TITLE
fix/5693-Reported_Emissions-API-Not-Returning-Stack-Pipe

### DIFF
--- a/src/derived-hourly/derived-hourly.repository.spec.ts
+++ b/src/derived-hourly/derived-hourly.repository.spec.ts
@@ -9,6 +9,7 @@ const mockedQueryBuilder = {
   leftJoin: jest.fn().mockReturnThis(),
   select: jest.fn().mockReturnThis(),
   where: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
   getQueryAndParameters: jest.fn(),
 };
 

--- a/src/hourly-operating/hourly-operating.repository.spec.ts
+++ b/src/hourly-operating/hourly-operating.repository.spec.ts
@@ -9,6 +9,7 @@ const mockedQueryBuilder = {
   leftJoin: jest.fn().mockReturnThis(),
   select: jest.fn().mockReturnThis(),
   where: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
   getQueryAndParameters: jest.fn(),
 };
 

--- a/src/hourly-operating/hourly-operating.repository.ts
+++ b/src/hourly-operating/hourly-operating.repository.ts
@@ -45,7 +45,6 @@ export class HourlyOperatingRepository extends Repository<HrlyOpData> {
             qb.where(unitPlantConditions)
               .orWhere(stackPipePlantConditions)
         }));
-        
 
     if (params.locationName) {
       const locationStrings = params.locationName

--- a/src/hourly-operating/hourly-operating.repository.ts
+++ b/src/hourly-operating/hourly-operating.repository.ts
@@ -45,6 +45,7 @@ export class HourlyOperatingRepository extends Repository<HrlyOpData> {
             qb.where(unitPlantConditions)
               .orWhere(stackPipePlantConditions)
         }));
+        
 
     if (params.locationName) {
       const locationStrings = params.locationName


### PR DESCRIPTION
…to return data for both units and stack/pipes.  Stack/pipes were not previously returned.

The following API calls did not return the expected  stack/pipe data:
- [Streaming Services - Hourly Op Data](https://api.epa.gov/easey/dev/streaming-services/emissions/hourly/operating?orisCode=3&locationName=CS0AAN&beginDate=2022-05-31&endDate=2022-07-01)
- [Streaming Services - Derived Hourly Data](https://api.epa.gov/easey/dev/streaming-services/emissions/hourly/derived-values?orisCode=3&locationName=1|2|CS0AAN&beginDate=2022-05-31&endDate=2022-07-01)

Ticket: [Kanban #5693](https://app.zenhub.com/workspaces/tech-team-kanban-board-5f36c9f5ad78a3000f8d20af/issues/gh/us-epa-camd/easey-ui/5693)