### PR TITLE
fix:facilities owneroperator join with pipe

### DIFF
--- a/src/facilities/facilities.service.ts
+++ b/src/facilities/facilities.service.ts
@@ -61,7 +61,7 @@ export class FacilitiesService {
             .slice(0, -1)
             .split('),');
           const ownOprUniqueList = [...new Set(ownOprList)];
-          const ownerOperator = ownOprUniqueList.join('),');
+          const ownerOperator = ownOprUniqueList.join(')|');
 
           const generatorIdArr = data.associatedGeneratorsAndNameplateCapacity?.split(
             ', ',


### PR DESCRIPTION
## Ticket
[Change delimiter in OwnerOperator ](https://github.com/US-EPA-CAMD/easey-ui/issues/4888)

## Changes

- Update ownerOperator join with pipe

## Step to test

1. Call facilities/attributes API
2. year=2021 and stateCode=IA