### PR TITLE
fix(6185): single case of switching from 'null' to 'IsNull()'

### DIFF
--- a/src/validators/is-allowance-program.validator.ts
+++ b/src/validators/is-allowance-program.validator.ts
@@ -4,7 +4,7 @@ import {
   ValidatorConstraintInterface,
 } from 'class-validator';
 import { Injectable } from '@nestjs/common';
-import { EntityManager } from 'typeorm';
+import { EntityManager, IsNull } from 'typeorm';
 
 import { ProgramCode } from '../entities/program-code.entity';
 
@@ -21,7 +21,7 @@ export class IsAllowanceProgramValidator
       found = await this.entityManager.findOneBy(ProgramCode, {
         programCode: value.toUpperCase(),
         allowanceUIFilter: 1,
-        tradingEndDate: null,
+        tradingEndDate: IsNull(),
       });
     } else {
       found = await this.entityManager.findOneBy(ProgramCode, {


### PR DESCRIPTION
## Main Changes

- While working on [updating CAMPD](https://github.com/US-EPA-CAMD/easey-ui/issues/6290), I found one more case where `null` was being passed as a value to a TypeORM `find*` function, which was deprecated in **v0.3.0**. I switched this out for the `IsNull()` helper.