### PR TITLE
Sprint 10 - statement timeout

### DIFF
--- a/manifest-vars.beta.yml
+++ b/manifest-vars.beta.yml
@@ -2,3 +2,4 @@ instances: 4
 environment: beta
 host: api-easey-beta.app.cloud.gov
 apiHost: api.epa.gov/easey/beta
+statementTimeout: 300000

--- a/manifest-vars.perf.yml
+++ b/manifest-vars.perf.yml
@@ -2,3 +2,4 @@ instances: 4
 environment: performance
 host: api-easey-perf.app.cloud.gov
 apiHost: api.epa.gov/easey/perf
+statementTimeout: 300000

--- a/manifest-vars.prod.yml
+++ b/manifest-vars.prod.yml
@@ -2,3 +2,4 @@ instances: 8
 environment: production
 host: api-easey.app.cloud.gov
 apiHost: api.epa.gov/easey
+statementTimeout: 300000

--- a/manifest-vars.staging.yml
+++ b/manifest-vars.staging.yml
@@ -2,3 +2,4 @@ instances: 4
 environment: staging
 host: api-easey-stg.app.cloud.gov
 apiHost: api.epa.gov/easey/staging
+statementTimeout: 300000

--- a/manifest-vars.test.yml
+++ b/manifest-vars.test.yml
@@ -2,3 +2,4 @@ instances: 2
 environment: testing
 host: api-easey-tst.app.cloud.gov
 apiHost: api.epa.gov/easey/test
+statementTimeout: 300000

--- a/manifest-vars.yml
+++ b/manifest-vars.yml
@@ -11,3 +11,4 @@ description: Streaming services API contains endpoints to stream account, allowa
 environment: development
 apiHost: api.epa.gov/easey/dev
 dbSvc: camd-pg-db
+statementTimeout: 300000

--- a/manifest.yml
+++ b/manifest.yml
@@ -24,6 +24,7 @@ applications:
       EASEY_STREAMING_SERVICES_CONNECTION_TIMEOUT: 10000
       EASEY_API_GATEWAY_HOST: ((apiHost))
       TZ: America/New_York
+      EASEY_DB_STATEMENT_TIMEOUT: ((statementTimeout))
     routes:
       - route: ((host))/((path))
     services:

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -69,6 +69,7 @@ export default registerAs('app', () => ({
     'EASEY_STREAMING_SERVICES_CONNECTION_TIMEOUT',
     10000,
   ),
+  statementTimeout: getConfigValueNumber('EASEY_DB_STATEMENT_TIMEOUT',300000),
   // ENABLES DEBUG CONSOLE LOGS
   enableDebug: getConfigValueBoolean('EASEY_STREAMING_SERVICES_ENABLE_DEBUG'),
   apiHost: apiHost,

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -35,6 +35,9 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
       entities: [__dirname + '/../**/*.entity.{js,ts}'],
       synchronize: false,
       ssl: this.tlsOptions,
+      extra: {
+        statement_timeout: this.configService.get<number>('app.statementTimeout'),
+      },
     };
   }
 }


### PR DESCRIPTION
## Pull Request
Ticket 6350, Added a statement_timeout parameter (integer) to abort any statement in a query that takes more than the specified amount of time to run.