### PR TITLE
6295 Filtering on owner/operator column in account data not pulling all accounts

### DIFF
--- a/src/constants/emissions-field-mappings.ts
+++ b/src/constants/emissions-field-mappings.ts
@@ -227,6 +227,8 @@ annual.push(
   {...propertyMetadata.unit_id.fieldLabels},
   { ...propertyMetadata.associatedStacks.fieldLabels },
   { ...propertyMetadata.year.fieldLabels },
+  { ...propertyMetadata.emissions.addDate.fieldLabels},
+  { ...propertyMetadata.emissions.userId.fieldLabels},
   ...commonEmissions,
   ...unitCharacteristics,
   ...controlInfoCharacteristics,

--- a/src/dto/annual-apportioned-emissions.dto.ts
+++ b/src/dto/annual-apportioned-emissions.dto.ts
@@ -36,4 +36,18 @@ export class AnnualApportionedEmissionsDTO extends ApportionedEmissionsDTO {
   })
   @IsNumber()
   unit_id: number;
+
+  @ApiProperty({
+    description: propertyMetadata.emissions.addDate.description,
+    example: propertyMetadata.emissions.addDate.example,
+    name: propertyMetadata.emissions.addDate.fieldLabels.value,
+  })
+  addDate?: Date;
+
+  @ApiProperty({
+    description: propertyMetadata.emissions.userId.description,
+    example: propertyMetadata.emissions.userId.example,
+    name: propertyMetadata.emissions.userId.fieldLabels.value,
+  })
+  userId?: string;
 }

--- a/src/utils/account-query-builder.ts
+++ b/src/utils/account-query-builder.ts
@@ -42,12 +42,10 @@ export class AccountQueryBuilder {
       let string = '(';
 
       for (let i = 0; i < dto.ownerOperator.length; i++) {
-        const regex = Regex.commaDelimited(dto.ownerOperator[i].toUpperCase());
-
         if (i === 0) {
-          string += `(UPPER(${characteristicAlias}.ownerOperator) ~* ${regex}) `;
+          string += `(UPPER(${characteristicAlias}.ownerOperator) LIKE '%${dto.ownerOperator[i].toUpperCase()}%') `;
         } else {
-          string += `OR (UPPER(${characteristicAlias}.ownerOperator) ~* ${regex}) `;
+          string += `OR (UPPER(${characteristicAlias}.ownerOperator) LIKE '%${dto.ownerOperator[i].toUpperCase()}%') `;
         }
       }
 


### PR DESCRIPTION
Ticket
https://github.com/US-EPA-CAMD/easey-ui/issues/6295

Changes
Updated Filtering by Owner/Operator in order to return any associated accounts, allowances, and transactions.