### PR TITLE
Update package.json to use tilde for easey-common versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/platform-express": "^8.1.1",
     "@nestjs/swagger": "^5.1.2",
     "@nestjs/typeorm": "^8.0.3",
-    "@us-epa-camd/easey-common": "^17.7.1",
+    "@us-epa-camd/easey-common": "~17.8.2",
     "JSONStream": "^1.3.5",
     "class-transformer": "0.4.0",
     "class-validator": "^0.14.0",


### PR DESCRIPTION
change the versioning for easey-common dependency to use tilde to avoid picking up anything but minor updates