### PR TITLE
Update easey-common version reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/platform-express": "^8.1.1",
     "@nestjs/swagger": "^5.1.2",
     "@nestjs/typeorm": "^8.0.3",
-    "@us-epa-camd/easey-common": "^17.7.1",
+    "@us-epa-camd/easey-common": "17.7.1",
     "JSONStream": "^1.3.5",
     "class-transformer": "0.4.0",
     "class-validator": "^0.14.0",


### PR DESCRIPTION
remove caret from easey-common version to prevent picking up newer (potentially incompatible) versions
