### PR TITLE
fix/#6648 RGGI API Changes for Emissions

### DIFF
--- a/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.controller.ts
@@ -85,31 +85,21 @@ export class QuarterlyApportionedEmissionsController {
   @ApiOkResponse({
     description:
       'Streams Last Updated Quarterly Apportioned Emissions data filtered by timestamp with a next timestamp returned',
-    content: {
-      'application/json': {
-        schema: {
-          type: 'object',
-          properties: {
-            nextTimestamp: {
-              type: 'string',
-              example: '2025-04-01T12:00:00Z',
-            },
-            data: {
-              type: 'array',
-              items: { $ref: getSchemaPath(QuarterlyApportionedEmissionsDTO) },
-            },
+      content: {
+        'application/json': {
+          schema: {
+            $ref: getSchemaPath(QuarterlyApportionedEmissionsDTO),
+          },
+        },
+        'text/csv': {
+          schema: {
+            type: 'string',
+            example: fieldMappings.emissions.quarterly.data.aggregation.unit
+              .map(i => i.label)
+              .join(','),
           },
         },
       },
-      'text/csv': {
-        schema: {
-          type: 'string',
-          example: fieldMappings.emissions.quarterly.data.aggregation.unit
-            .map(i => i.label)
-            .join(','),
-        },
-      },
-    },
   })
   @BadRequestResponse()
   @NotFoundResponse()

--- a/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.service.ts
+++ b/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.service.ts
@@ -84,29 +84,17 @@ export class QuarterlyApportionedEmissionsService {
       params,
     );
 
-    const collectedData = [];
+    // Set next-time-stamp in response header
+    req.res.setHeader('next-time-stamp', currentDbTimestamp);
 
     const json2Dto = new Transform({
       objectMode: true,
-      writableObjectMode: true,
-      readableObjectMode: true,
-    
       transform(data, _enc, callback) {
-        const excludedData = exclude(data, params, ExcludeApportionedEmissions);
-        const dto = plainToClass(QuarterlyApportionedEmissionsDTO, excludedData, {
+        data = exclude(data, params, ExcludeApportionedEmissions);
+        const dto = plainToClass(QuarterlyApportionedEmissionsDTO, data, {
           enableImplicitConversion: true,
         });
-        collectedData.push(dto);
-        callback();
-      },
-    
-      flush(callback) {
-        const finalResponseObject = {
-          nextTimestamp: currentDbTimestamp,
-          data: collectedData,
-        };
-        this.push(finalResponseObject);
-        callback();
+        callback(null, dto);
       },
     });
 

--- a/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.service.ts
+++ b/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.service.ts
@@ -85,7 +85,7 @@ export class QuarterlyApportionedEmissionsService {
     );
 
     // Set next-time-stamp in response header
-    req.res.setHeader('next-time-stamp', currentDbTimestamp);
+    req.res.setHeader('next-timestamp', currentDbTimestamp);
 
     const json2Dto = new Transform({
       objectMode: true,


### PR DESCRIPTION
### **Related Ticket:**

- ticket [#6648](https://github.com/US-EPA-CAMD/easey-ui/issues/6648)

### **Updates:**

- Added next-time-stamp field in the response header for endpoint QuarterlyApportionedEmissionsController.streamLastUpdatedEmissions.
- Updated the example in the Swagger page.