### PR TITLE
fix/#6648 RGGI API Changes for Emissions for release v2.0

### DIFF
--- a/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.controller.ts
+++ b/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.controller.ts
@@ -88,17 +88,7 @@ export class QuarterlyApportionedEmissionsController {
     content: {
       'application/json': {
         schema: {
-          type: 'object',
-          properties: {
-            nextTimestamp: {
-              type: 'string',
-              example: '2025-04-01T12:00:00Z',
-            },
-            data: {
-              type: 'array',
-              items: { $ref: getSchemaPath(QuarterlyApportionedEmissionsDTO) },
-            },
-          },
+          $ref: getSchemaPath(QuarterlyApportionedEmissionsDTO),
         },
       },
       'text/csv': {

--- a/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.service.ts
+++ b/src/apportioned-emissions/quarterly/quarterly-apportioned-emissions.service.ts
@@ -84,29 +84,17 @@ export class QuarterlyApportionedEmissionsService {
       params,
     );
 
-    const collectedData = [];
+    // Set next-time-stamp in response header
+    req.res.setHeader('next-timestamp', currentDbTimestamp);
 
     const json2Dto = new Transform({
       objectMode: true,
-      writableObjectMode: true,
-      readableObjectMode: true,
-
       transform(data, _enc, callback) {
-        const excludedData = exclude(data, params, ExcludeApportionedEmissions);
-        const dto = plainToClass(QuarterlyApportionedEmissionsDTO, excludedData, {
+        data = exclude(data, params, ExcludeApportionedEmissions);
+        const dto = plainToClass(QuarterlyApportionedEmissionsDTO, data, {
           enableImplicitConversion: true,
         });
-        collectedData.push(dto);
-        callback();
-      },
-
-      flush(callback) {
-        const finalResponseObject = {
-          nextTimestamp: currentDbTimestamp,
-          data: collectedData,
-        };
-        this.push(finalResponseObject);
-        callback();
+        callback(null, dto);
       },
     });
 


### PR DESCRIPTION
### **Related Ticket:**

- ticket [#6648](https://github.com/US-EPA-CAMD/easey-ui/issues/6648)

### **Updates:**

- Added the next-timestamp property in the response header for endpoint in QuarterlyApportionedEmissionsController.streamLastUpdatedEmissions.
- Updated the given example in the swagger page.