### PR TITLE
#7186 prevent a statement timeout from bringing the entire app down

### DIFF
--- a/src/streaming/streaming.service.spec.ts
+++ b/src/streaming/streaming.service.spec.ts
@@ -1,0 +1,112 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { PassThrough, Readable } from 'stream';
+import { StreamableFile } from '@nestjs/common';
+
+import { Logger } from '@us-epa-camd/easey-common/logger';
+
+import { StreamingService } from './streaming.service';
+
+describe('-- Streaming Service --', () => {
+  let service: StreamingService;
+  let logger: { log: jest.Mock; error: jest.Mock };
+  let dbClient: { query: jest.Mock; release: jest.Mock };
+  let dbStream: Readable;
+
+  const mockRequest = () => ({
+    headers: { accept: 'application/json' },
+    res: { setHeader: jest.fn() },
+    on: jest.fn(),
+  });
+
+  // `dtoTransform` is supplied by the calling service in production; an
+  // object-mode passthrough is enough to stand in for it here.
+  const callGetStream = (req: any) =>
+    service.getStream(
+      req,
+      'SELECT 1',
+      [],
+      new PassThrough({ objectMode: true }),
+      'file',
+      [],
+    );
+
+  beforeEach(async () => {
+    dbStream = new Readable({ objectMode: true, read() {} });
+    dbClient = {
+      query: jest.fn().mockReturnValue(dbStream),
+      release: jest.fn(),
+    };
+    logger = { log: jest.fn(), error: jest.fn() };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        StreamingService,
+        { provide: Logger, useValue: logger },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue(20000) },
+        },
+        {
+          provide: 'PG-POOL',
+          useValue: { connect: jest.fn().mockResolvedValue(dbClient) },
+        },
+      ],
+    }).compile();
+
+    service = module.get(StreamingService);
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  it('returns a StreamableFile and sets the field-mappings header (happy path)', async () => {
+    const req = mockRequest();
+
+    const result = await callGetStream(req);
+
+    expect(result).toBeInstanceOf(StreamableFile);
+    expect(req.res.setHeader).toHaveBeenCalledWith(
+      'X-Field-Mappings',
+      expect.any(String),
+    );
+  });
+
+  it('handles a DB stream error without crashing — logs it and releases the client', async () => {
+    const req = mockRequest();
+    await callGetStream(req);
+
+    // Simulate the statement_timeout cancellation seen in production. Before the
+    // Defect 1 fix this unhandled 'error' became an uncaughtException.
+    dbStream.emit(
+      'error',
+      new Error('canceling statement due to statement timeout'),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Stream query failed'),
+    );
+    // Released exactly once even though the error also destroys the downstream pipe.
+    expect(dbClient.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the client and logs completion when the stream ends', async () => {
+    const req = mockRequest();
+    const result = await callGetStream(req);
+
+    const underlying: any = (result as StreamableFile).getStream();
+    const ended = new Promise<void>((resolve) => {
+      underlying.on('data', () => {});
+      underlying.on('end', () => resolve());
+    });
+
+    dbStream.push(null); // end the source
+    await ended;
+
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('completed'),
+    );
+    expect(dbClient.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/streaming/streaming.service.spec.ts
+++ b/src/streaming/streaming.service.spec.ts
@@ -19,7 +19,7 @@ describe('-- Streaming Service --', () => {
     on: jest.fn(),
   });
 
-  // `dtoTransform` is supplied by the calling service in production; an
+  // `dtoTransform` is supplied by the calling service; an
   // object-mode passthrough is enough to stand in for it here.
   const callGetStream = (req: any) =>
     service.getStream(
@@ -75,8 +75,7 @@ describe('-- Streaming Service --', () => {
     const req = mockRequest();
     await callGetStream(req);
 
-    // Simulate the statement_timeout cancellation seen in production. Before the
-    // Defect 1 fix this unhandled 'error' became an uncaughtException.
+    // Simulate a statement_timeout cancellation
     dbStream.emit(
       'error',
       new Error('canceling statement due to statement timeout'),

--- a/src/streaming/streaming.service.ts
+++ b/src/streaming/streaming.service.ts
@@ -32,26 +32,58 @@ export class StreamingService {
     });
 
     const dbClient = await this.dbPool.connect();
-    const dbStream = dbClient.query(queryStream).pipe(dtoTransform);
 
-      req.on('close', () => {
-        dbClient.release();
-        this.logger.log('Client Released');
-      });
+    // Release the pooled client exactly once, regardless of how the stream ends.
+    let released = false;
+    const releaseClient = () => {
+      if (released) return;
+      released = true;
+      dbClient.release();
+      this.logger.log('Client Released');
+    };
 
-      req.res.setHeader('X-Field-Mappings', JSON.stringify(fieldMappings));
+    const isCsv = req.headers.accept === 'text/csv';
+    const finalTransform = isCsv
+      ? new Json2CSV(fieldMappings)
+      : JSONStream.stringify();
 
-      if (req.headers.accept === 'text/csv') {
-        const json2Csv = new Json2CSV(fieldMappings);
-        return new StreamableFile(dbStream.pipe(json2Csv), {
-          type: req.headers.accept,
-          disposition: `${disposition}.csv`,
-        });
+    const startTime = Date.now();
+    const dbQueryStream = dbClient.query(queryStream);
+    const outStream = dbQueryStream.pipe(dtoTransform).pipe(finalTransform);
+
+    // A DB stream error (e.g. a statement_timeout cancellation) must be handled here.
+    // log the error with how long it ran and the SQL, release the client, and propagate
+    // the error to the response stream so only this request fails.
+    let errored = false;
+    const onStreamError = (err: Error) => {
+      if (errored) return;
+      errored = true;
+      this.logger.error(
+        `Stream query failed after ${Date.now() - startTime}ms: ` + `${err?.stack ?? err}. SQL: ${sql} -- params: ${JSON.stringify(params)}`,
+      );
+      releaseClient();
+      if (!outStream.destroyed) {
+        outStream.destroy(err);
       }
+    };
 
-      return new StreamableFile(dbStream.pipe(JSONStream.stringify()), {
-        type: req.headers.accept,
-        disposition: `${disposition}.json`,
-      });
+    dbQueryStream.on('error', onStreamError);
+    dtoTransform.on('error', onStreamError);
+    finalTransform.on('error', onStreamError);
+
+    // Release the client when the request is aborted or the stream finishes.
+    req.on('close', releaseClient);
+    outStream.on('close', releaseClient);
+    outStream.on('end', () => {
+      this.logger.log(`Stream query completed in ${Date.now() - startTime}ms`);
+      releaseClient();
+    });
+
+    req.res.setHeader('X-Field-Mappings', JSON.stringify(fieldMappings));
+
+    return new StreamableFile(outStream, {
+      type: req.headers.accept,
+      disposition: isCsv ? `${disposition}.csv` : `${disposition}.json`,
+    });
   }
 }


### PR DESCRIPTION
#7186 prevent a statement timeout from bringing the entire app down. Log errors and query elapsed times.